### PR TITLE
Update testing and remove hard-coded scalings

### DIFF
--- a/src/interpolations.jl
+++ b/src/interpolations.jl
@@ -1910,16 +1910,17 @@ end
 
 # RefHexahedron, 1st order Lagrange
 # https://defelement.com/elements/examples/hexahedron-raviart-thomas-lagrange-1.html
+# Scale with factor 1/4 as Ferrite has 4 times defelement's face area.
 function reference_shape_value(ip::RaviartThomas{RefHexahedron, 1}, ξ::Vec{3, T}, i::Int) where {T}
     x, y, z = ξ
     nil = zero(T)
 
-    i == 1 && return Vec(nil, nil, (z - 1) / 2) # Changed sign, follow Ferrite's sign convention
-    i == 2 && return Vec(nil, (y - 1) / 2, nil)
-    i == 3 && return Vec((x + 1) / 2, nil, nil)
-    i == 4 && return Vec(nil, (y + 1) / 2, nil) # Changed sign, follow Ferrite's sign convention
-    i == 5 && return Vec((x - 1) / 2, nil, nil) # Changed sign, follow Ferrite's sign convention
-    i == 6 && return Vec(nil, nil, (z + 1) / 2)
+    i == 1 && return Vec(nil, nil, (z - 1) / 8) # Changed sign, follow Ferrite's sign convention
+    i == 2 && return Vec(nil, (y - 1) / 8, nil)
+    i == 3 && return Vec((x + 1) / 8, nil, nil)
+    i == 4 && return Vec(nil, (y + 1) / 8, nil) # Changed sign, follow Ferrite's sign convention
+    i == 5 && return Vec((x - 1) / 8, nil, nil) # Changed sign, follow Ferrite's sign convention
+    i == 6 && return Vec(nil, nil, (z + 1) / 8)
     throw(ArgumentError("no shape function $i for interpolation $ip"))
 end
 

--- a/test/test_interpolations.jl
+++ b/test/test_interpolations.jl
@@ -363,35 +363,35 @@ end
 
         # These reference moments define the functionals that an interpolation should fulfill
         ## Raviart-Thomas on RefTriangle
-        reference_edge_moment(::RaviartThomas{RefTriangle, 1}, s::SVector{1}, edge_shape_nr) = 1
-        reference_edge_moment(::RaviartThomas{RefTriangle, 2}, s::SVector{1}, edge_shape_nr) = edge_shape_nr == 1 ? (1 - s[1]) : s[1]
-        reference_face_moment(::RaviartThomas{RefTriangle, 2}, s::SVector{2}, face_shape_nr) = face_shape_nr == 1 ? Vec(1, 0) : Vec(0, 1)
+        reference_edge_moment(::RaviartThomas{RefTriangle, 1}, edge_shape_nr, s) = 1
+        reference_edge_moment(::RaviartThomas{RefTriangle, 2}, edge_shape_nr, s) = edge_shape_nr == 1 ? (1 - s) : s
+        reference_face_moment(::RaviartThomas{RefTriangle, 2}, face_shape_nr, s1, s2) = face_shape_nr == 1 ? Vec(1, 0) : Vec(0, 1)
 
         ## Raviart-Thomas on RefQuadrilateral
-        reference_edge_moment(::RaviartThomas{RefQuadrilateral, 1}, s::SVector{1}, edge_shape_nr) = 1
+        reference_edge_moment(::RaviartThomas{RefQuadrilateral, 1}, edge_shape_nr, s) = 1
 
         ## Raviart-Thomas on RefTetrahedron
-        reference_face_moment(::RaviartThomas{RefTetrahedron, 1}, s::SVector{2}, face_shape_nr) = 1
+        reference_face_moment(::RaviartThomas{RefTetrahedron, 1}, face_shape_nr, s1, s2) = 1
 
         ## Raviart-Thomas on RefHexahedron
-        reference_face_moment(::RaviartThomas{RefHexahedron, 1}, s::SVector{2}, face_shape_nr) = 1
+        reference_face_moment(::RaviartThomas{RefHexahedron, 1}, face_shape_nr, s1, s2) = 1
 
         ## Brezzi-Douglas-Marini on RefTriangle
-        reference_edge_moment(::BrezziDouglasMarini{RefTriangle, 1}, s::SVector{1}, edge_shape_nr) = edge_shape_nr == 1 ? (1 - s[1]) : s[1]
+        reference_edge_moment(::BrezziDouglasMarini{RefTriangle, 1}, edge_shape_nr, s) = edge_shape_nr == 1 ? (1 - s) : s
 
         ## Nedelec on RefTriangle
-        reference_edge_moment(::Nedelec{RefTriangle, 1}, s::SVector{1}, edge_shape_nr) = 1
-        reference_edge_moment(::Nedelec{RefTriangle, 2}, s::SVector{1}, edge_shape_nr) = edge_shape_nr == 1 ? (1 - s[1]) : s[1]
-        reference_face_moment(::Nedelec{RefTriangle, 2}, s::SVector{2}, face_shape_nr) = face_shape_nr == 1 ? Vec(1, 0) : Vec(0, 1)
+        reference_edge_moment(::Nedelec{RefTriangle, 1}, edge_shape_nr, s) = 1
+        reference_edge_moment(::Nedelec{RefTriangle, 2}, edge_shape_nr, s) = edge_shape_nr == 1 ? (1 - s) : s
+        reference_face_moment(::Nedelec{RefTriangle, 2}, face_shape_nr, s1, s2) = face_shape_nr == 1 ? Vec(1, 0) : Vec(0, 1)
 
         ## Nedelec on RefQuadrilateral
-        reference_edge_moment(::Nedelec{RefQuadrilateral, 1}, s::SVector{1}, edge_shape_nr) = 1
+        reference_edge_moment(::Nedelec{RefQuadrilateral, 1}, edge_shape_nr, s) = 1
 
         ## Nedelec on RefTetrahedron
-        reference_edge_moment(::Nedelec{RefTetrahedron, 1}, s::SVector{1}, edge_shape_nr) = 1
+        reference_edge_moment(::Nedelec{RefTetrahedron, 1}, edge_shape_nr, s) = 1
 
         ## Nedelec on RefHexahedron
-        reference_edge_moment(::Nedelec{RefHexahedron, 1}, s::SVector{1}, edge_shape_nr) = 1
+        reference_edge_moment(::Nedelec{RefHexahedron, 1}, edge_shape_nr, s) = 1
 
         function_space(::RaviartThomas) = Val(:Hdiv)
         function_space(::BrezziDouglasMarini) = Val(:Hdiv)
@@ -399,88 +399,100 @@ end
         # function_space(::Lagrange) = Val(:H1)
         # function_space(::DiscontinuousLagrange) = Val(:L2)
 
-        function test_interpolation_functionals(ip::Interpolation)
-            return test_interpolation_functionals(function_space(ip), Val(Ferrite.getrefdim(ip)), ip)
-        end
-
         """
             integrate_edge(f)
 
-        Integrate f(s) on the domain s ∈ [0, 1]
+        Integrate f(s) on the unit line, s ∈ [0, 1]
         """
         function integrate_edge(f)
-            val, _ = hquadrature(s -> f(SVector(s)), 0, 1; atol = 1.0e-8)
+            val, _ = hquadrature(f, 0, 1; atol = 1.0e-8)
             return val
         end
 
         """
-            integrate_face(::Type{RefTriangle}, f)
+            integrate_face(f)
 
-        Integrate f(s) on a triangular domain using the Duffy transform;
-        The transformed function is integrated on the square domain s ∈ [0, 1] × [0, 1]
+        Integrate f(s1, s2) on the unit square, (s1,s2) ∈ [0, 1] × [0, 1]
         """
-        function integrate_face(::Type{RefTriangle}, f)
-            duffy_transform(s) = SVector(s[1] * (1 - s[2]), s[2]) # (x, y) = (u(1 - v), v)
-            duffy_detJ(s) = 1 - s[2]
-            F(s) = f(duffy_transform(s)) * duffy_detJ(s)
-
-            val, _ = hcubature(F, (0, 0), (1, 1); atol = 1.0e-8)
+        function integrate_face(f::Function)
+            val, _ = hcubature(z -> f(z[1], z[2]), (0, 0), (1, 1); atol = 1.0e-8)
             return val
         end
 
-        """
-            integrate_face(::Type{RefQuadrilateral}, f)
+        parameterize_edge(edge_coords, s) = edge_coords[1] + (edge_coords[2] - edge_coords[1]) * s
 
-        Integrate f(s) on the square domain s ∈ [0, 1] × [0, 1]
-        """
-        function integrate_face(::Type{RefQuadrilateral}, f)
-            val, _ = hcubature(f, (0, 0), (1, 1); atol = 1.0e-8)
-            return val
+        function parameterize_face(face_coords, s1, s2)
+            ξ0 = face_coords[1]
+            v1 = face_coords[2] - ξ0
+            v2 = face_coords[end] - ξ0
+            if length(face_coords) == 3 # Triangle
+                return ξ0 + s1 * (1 - s2 / 2) * v1 + s2 * (1 - s1 / 2) * v2
+            elseif length(face_coords) == 4 # Quadrilateral
+                return ξ0 + s1 * v1 + s2 * v2
+            else
+                throw(ArgumentError("length(face_coords) must be 3 or 4"))
+            end
         end
 
-        parameterize_edge(edge_coords, s::SVector{1}) = edge_coords[1] + (edge_coords[2] - edge_coords[1]) * s[1]
-        parameterize_face(face_coords, s::SVector{2}) = face_coords[1] + (face_coords[2] - face_coords[1]) * s[1] + (face_coords[end] - face_coords[1]) * s[2]
-        # parameterize_volume(volume_coords, s::SVector{3}) = # TODO parameterization of volume (Tetrahedron, Hexahedron, Prism, Pyramid)
+        # parameterize_volume(volume_coords, s1, s2, s3) = # TODO parameterization of volume (Tetrahedron, Hexahedron, Prism, Pyramid)
 
-        # TODO why is this necessary
-        reference_face_weight(RefShape::Type{RefTriangle}) = 1 / reference_volume(RefShape)
-        reference_face_weight(RefShape::Type{RefQuadrilateral}) = 1 / reference_volume(RefShape)
+        edge_weight(ξ::F, s) where {F <: Function} = norm(gradient(ξ, s))
+        face_weight(ξ::F, s1, s2) where {F <: Function} = norm(gradient(s -> ξ(s, s2), s1) × gradient(s -> ξ(s1, s), s2))
+
+        function test_interpolation_functionals(ip::Interpolation)
+            @testset "functionals $ip" begin
+                test_interpolation_functionals(function_space(ip), Val(Ferrite.getrefdim(ip)), ip)
+            end
+        end
 
         # 2D, H(div)
         function test_interpolation_functionals(::Val{:Hdiv}, ::Val{2}, ip::Interpolation)
             RefShape = getrefshape(ip)
             ipg = Lagrange{RefShape, 1}()
 
-            # Test functionals associated with the edges (facets)
+            # Test functionals associated with the edges
             for edge_nr in 1:Ferrite.nedges(RefShape)
                 edge_coords = getindex.((Ferrite.reference_coordinates(ipg),), Ferrite.reference_edges(RefShape)[edge_nr])
                 dof_inds = Ferrite.edgedof_interior_indices(ip)[edge_nr]
 
-                ξ(s::SVector{1}) = parameterize_edge(edge_coords, s)
-                weighted_normal = reference_normals(RefShape)[edge_nr] * reference_facet_area(RefShape, edge_nr)
+                ξ(s) = parameterize_edge(edge_coords, s)
+                normal = reference_normals(RefShape)[edge_nr]
                 for (edge_shape_nr, shape_nr) in pairs(dof_inds)
-                    f(s) = reference_edge_moment(ip, s, edge_shape_nr) * (reference_shape_value(ip, ξ(s), shape_nr) ⋅ weighted_normal)
+                    f(s) = reference_edge_moment(ip, edge_shape_nr, s) * (reference_shape_value(ip, ξ(s), shape_nr) ⋅ normal) * edge_weight(ξ, s)
                     @test integrate_edge(f) ≈ 1
+                    # Test that the functional is zero for the other shape functions
+                    for other_shape_nr in 1:getnbasefunctions(ip)
+                        other_shape_nr == shape_nr && continue
+                        g(s) = reference_edge_moment(ip, edge_shape_nr, s) * (reference_shape_value(ip, ξ(s), other_shape_nr) ⋅ normal) * edge_weight(ξ, s)
+                        @test integrate_edge(g) + 1 ≈ 1 # integrate_edge(g) ≈ 0
+                    end
                 end
 
+                # Test that normal components of other shape functions are zero on this edge
+                # Stronger requirement than functionals being zero.
                 for shape_nr in 1:getnbasefunctions(ip)
-                    shape_nr in dof_inds && continue # Already tested
+                    shape_nr in dof_inds && continue
                     for s in range(0, 1, 5)
-                        @test abs(reference_shape_value(ip, ξ(SVector(s)), shape_nr) ⋅ weighted_normal) < 1.0e-10
+                        @test abs(reference_shape_value(ip, ξ(s), shape_nr) ⋅ normal) < 1.0e-10
                     end
                 end
             end
 
-            # Test functionals associated with the faces (volumes)
+            # Test functionals associated with the faces
             for face_nr in 1:Ferrite.nfaces(RefShape)
                 face_coords = getindex.((Ferrite.reference_coordinates(ipg),), Ferrite.reference_faces(RefShape)[face_nr])
-                weighted_area = reference_volume(RefShape) * reference_face_weight(RefShape)
                 dof_inds = Ferrite.facedof_interior_indices(ip)[face_nr]
 
-                ξ(s::SVector{2}) = parameterize_face(face_coords, s)
+                ξ(s1, s2) = parameterize_face(face_coords, s1, s2)
                 for (face_shape_nr, shape_nr) in pairs(dof_inds)
-                    f(s) = reference_face_moment(ip, s, face_shape_nr) ⋅ reference_shape_value(ip, ξ(s), shape_nr) * weighted_area
-                    @test integrate_face(RefShape, f) ≈ 1
+                    f(s1, s2) = reference_face_moment(ip, face_shape_nr, s1, s2) ⋅ reference_shape_value(ip, ξ(s1, s2), shape_nr) * face_weight(ξ, s1, s2)
+                    @test integrate_face(f) ≈ 1
+                    # Test that the functional is zero for the other shape functions
+                    for other_shape_nr in 1:getnbasefunctions(ip)
+                        other_shape_nr == shape_nr && continue
+                        g(s1, s2) = reference_face_moment(ip, face_shape_nr, s1, s2) ⋅ reference_shape_value(ip, ξ(s1, s2), other_shape_nr) * face_weight(ξ, s1, s2)
+                        @test integrate_face(g) + 1 ≈ 1 # integrate_edge(g) ≈ 0
+                    end
                 end
             end
         end
@@ -492,121 +504,84 @@ end
 
             # Test functionals associated with the faces
             for face_nr in 1:Ferrite.nfaces(RefShape)
-                face_shape = getfacetrefshape(RefShape, face_nr)
                 face_coords = getindex.((Ferrite.reference_coordinates(ipg),), Ferrite.reference_faces(RefShape)[face_nr])
-                weighted_normal = reference_normals(RefShape)[face_nr] * reference_facet_area(RefShape, face_nr) * reference_face_weight(face_shape)
+                normal = reference_normals(RefShape)[face_nr]
                 dof_inds = Ferrite.facedof_interior_indices(ip)[face_nr]
 
-                ξ(s::SVector{2}) = parameterize_face(face_coords, s)
+                ξ(s1, s2) = parameterize_face(face_coords, s1, s2)
                 for (face_shape_nr, shape_nr) in pairs(dof_inds)
-                    f(s) = reference_face_moment(ip, s, face_shape_nr) * (reference_shape_value(ip, ξ(s), shape_nr) ⋅ weighted_normal)
-                    @test integrate_face(face_shape, f) ≈ 1
+                    f(s1, s2) = reference_face_moment(ip, face_shape_nr, s1, s2) * (reference_shape_value(ip, ξ(s1, s2), shape_nr) ⋅ normal) * face_weight(ξ, s1, s2)
+                    @test integrate_face(f) ≈ 1
+                    # Test that the functional is zero for the other shape functions
+                    for other_shape_nr in 1:getnbasefunctions(ip)
+                        other_shape_nr == shape_nr && continue
+                        g(s1, s2) = reference_face_moment(ip, face_shape_nr, s1, s2) * (reference_shape_value(ip, ξ(s1, s2), other_shape_nr) ⋅ normal) * face_weight(ξ, s1, s2)
+                        @test integrate_face(g) + 1 ≈ 1 # integrate_edge(g) ≈ 0
+                    end
                 end
-            end
-
-            # Test functionals associated with the volume
-            # begin
-
-            # end
-        end
-
-        # 2D, H(curl)
-        function test_interpolation_functionals(::Val{:Hcurl}, ::Val{2}, ip::Interpolation)
-            RefShape = getrefshape(ip)
-            ipg = Lagrange{RefShape, 1}()
-
-            # Test functionals associated with the edges (facets)
-            for edge_nr in 1:Ferrite.nedges(RefShape)
-                edge_coords = getindex.((Ferrite.reference_coordinates(ipg),), Ferrite.reference_edges(RefShape)[edge_nr])
-                edge_vector = edge_coords[2] - edge_coords[1]
-                edge_vector = reference_facet_area(RefShape, edge_nr) * edge_vector / norm(edge_vector) # Weighted direction vector
-                dof_inds = Ferrite.edgedof_interior_indices(ip)[edge_nr]
-
-                ξ(s::SVector{1}) = parameterize_edge(edge_coords, s)
-                for (edge_shape_nr, shape_nr) in pairs(dof_inds)
-                    f(s) = reference_edge_moment(ip, s, edge_shape_nr) * (reference_shape_value(ip, ξ(s), shape_nr) ⋅ edge_vector)
-                    @test integrate_edge(f) ≈ 1
-                end
-
+                # Test that normal components of other shape functions are zero on this edge
+                # Stronger requirement than functionals being zero.
                 for shape_nr in 1:getnbasefunctions(ip)
-                    shape_nr in dof_inds && continue # Already tested
-                    for s in range(0, 1, 5)
-                        @test abs(reference_shape_value(ip, ξ(SVector(s)), shape_nr) ⋅ edge_vector) < 1.0e-10
+                    shape_nr in dof_inds && continue
+                    for s1 in range(0, 1, 5), s2 in range(0, 1, 5)
+                        @test abs(reference_shape_value(ip, ξ(s1, s2), shape_nr) ⋅ normal) < 1.0e-10
                     end
                 end
             end
 
-            # Test functionals associated with the faces (volumes)
-            for face_nr in 1:Ferrite.nfaces(RefShape)
-                face_coords = getindex.((Ferrite.reference_coordinates(ipg),), Ferrite.reference_faces(RefShape)[face_nr])
-                area = reference_volume(RefShape) * reference_face_weight(RefShape)
-                dof_inds = Ferrite.facedof_interior_indices(ip)[face_nr]
-
-                ξ(s::SVector{2}) = parameterize_face(face_coords, s)
-                for (face_shape_nr, shape_nr) in pairs(dof_inds)
-                    f(s) = reference_face_moment(ip, s, face_shape_nr) ⋅ reference_shape_value(ip, ξ(s), shape_nr) * area
-                    @test integrate_face(RefShape, f) ≈ 1
-                end
-            end
+            # Test functionals associated with the volume
+            @assert length(Ferrite.volumedof_interior_indices(ip)) == 0 # Should be supported when testing `ip`s with those.
         end
 
-        # 3D, H(curl)
-        function test_interpolation_functionals(::Val{:Hcurl}, ::Val{3}, ip::Interpolation)
+        # H(curl)
+        function test_interpolation_functionals(::Val{:Hcurl}, ::Union{Val{2}, Val{3}}, ip::Interpolation)
             RefShape = getrefshape(ip)
             ipg = Lagrange{RefShape, 1}()
 
             # Test functionals associated with the edges
             for edge_nr in 1:Ferrite.nedges(RefShape)
                 edge_coords = getindex.((Ferrite.reference_coordinates(ipg),), Ferrite.reference_edges(RefShape)[edge_nr])
-                edge_vector = edge_coords[2] - edge_coords[1] # Weighted direction vector
+                tangent = normalize(edge_coords[2] - edge_coords[1])
                 dof_inds = Ferrite.edgedof_interior_indices(ip)[edge_nr]
 
-                ξ(s::SVector{1}) = edge_coords[1] + edge_vector * s[1]
+                ξ(s) = parameterize_edge(edge_coords, s)
                 for (edge_shape_nr, shape_nr) in pairs(dof_inds)
-                    f(s) = reference_edge_moment(ip, s, edge_shape_nr) * (reference_shape_value(ip, ξ(s), shape_nr) ⋅ edge_vector)
+                    f(s) = reference_edge_moment(ip, edge_shape_nr, s) * (reference_shape_value(ip, ξ(s), shape_nr) ⋅ tangent) * edge_weight(ξ, s)
                     @test integrate_edge(f) ≈ 1
                 end
 
                 for shape_nr in 1:getnbasefunctions(ip)
                     shape_nr in dof_inds && continue # Already tested
                     for s in range(0, 1, 5)
-                        @test abs(reference_shape_value(ip, ξ(SVector(s)), shape_nr) ⋅ edge_vector) < 1.0e-10
+                        @test abs(reference_shape_value(ip, ξ(s), shape_nr) ⋅ tangent) < 1.0e-10
                     end
                 end
             end
 
             # Test functionals associated with the faces
             for face_nr in 1:Ferrite.nfaces(RefShape)
-                face_shape = getfacetrefshape(RefShape, face_nr)
                 face_coords = getindex.((Ferrite.reference_coordinates(ipg),), Ferrite.reference_faces(RefShape)[face_nr])
-                area = reference_facet_area(RefShape, face_nr) * reference_face_weight(face_shape)
                 dof_inds = Ferrite.facedof_interior_indices(ip)[face_nr]
 
-                ξ(s::SVector{2}) = face_coords[1] + (face_coords[2] - face_coords[1]) * s[1] + (face_coords[end] - face_coords[1]) * s[2]
+                ξ(s1, s2) = parameterize_face(face_coords, s1, s2)
                 for (face_shape_nr, shape_nr) in pairs(dof_inds)
-                    f(s) = reference_face_moment(ip, s, face_shape_nr) ⋅ reference_shape_value(ip, ξ(s), shape_nr) * area
-                    @test integrate_face(face_shape, f) ≈ 1
+                    f(s1, s2) = reference_face_moment(ip, face_shape_nr, s1, s2) ⋅ reference_shape_value(ip, ξ(s1, s2), shape_nr) * face_weight(ξ, s1, s2)
+                    @test integrate_face(f) ≈ 1
                 end
             end
 
-            # Test functionals associated with the volumes
-            # begin
-            #     volume_coords =
-            #     dof_inds = Ferrite.volumedof_interior_indices(ip)
-
-            #     ξ(s::Vec{3}) = parameterize_volume(volume_coords, s)
-            #     for (volume_shape_nr, shape_nr) in pairs(dof_inds)
-            #         f(s) = reference_moment(ip, s, volume_shape_nr) ⋅ reference_shape_value(ip, ξ(s), shape_nr)
-            #         # TODO integration on volume (Tetrahedron, Hexahedron, Prism, Pyramid)
-            #     end
-            # end
+            # Test functionals associated with volume
+            @assert length(Ferrite.volumedof_interior_indices(ip)) == 0 # Test not supported yet, but needs to be if introduced ip with volumedofs.
         end
 
-        test_interpolation_properties.(Hcurl_interpolations)  # Requires PR1136
-        test_interpolation_properties.(Hdiv_interpolations)   # Requires PR1136
-
-        test_interpolation_functionals.(Hcurl_interpolations)
-        test_interpolation_functionals.(Hdiv_interpolations)
+        @testset "Interpolation properties" begin
+            test_interpolation_properties.(Hcurl_interpolations)
+            test_interpolation_properties.(Hdiv_interpolations)
+        end
+        @testset "Interpolation functionals" begin
+            test_interpolation_functionals.(Hcurl_interpolations)
+            test_interpolation_functionals.(Hdiv_interpolations)
+        end
     end
 
 end # testset


### PR DESCRIPTION
Instead of giving comments directly on https://github.com/Ferrite-FEM/Ferrite.jl/pull/1162, I've opened a PR towards your branch here. 

I believe this generalization should give the correct results now. The basic idea is essentially using the Duffy transformation directly in the parameterization for triangular faces, and always integrate on the (0,1) x (0,1) domain for (s1 x s2). 

This removes the need to use the weighted normal/edge vectors, and removes all the area scaling as this is now inherited from the edge/face parameterization (`edge_weight` and `face_weight` functions). 

I also opted for using explicit (s1, s2) and (s) for face/edge parameterization instead of going via `SVector`, and re-ordered the arguments of `reference_[face/edge]_moment` as that became more logical in that case. 

Finally, could merge into `test_interpolation_functionals(::Val{:Hcurl}, ::Union{Val{2}, Val{3}}, ip::Interpolation)` for H(curl). Was not possible easily for H(div), and I think it is fine to keep two functions here for now at least...

Please take a look through and check if you agree to these changes, and then you can merge it into your branch, which should update https://github.com/Ferrite-FEM/Ferrite.jl/pull/1162 automatically.